### PR TITLE
Allow users to bind to specific IP in port config

### DIFF
--- a/src/clj_docker_client/utils.clj
+++ b/src/clj_docker_client/utils.clj
@@ -82,12 +82,25 @@
         (conj args current-arg)
         args))))
 
+(defn port-binding-default-public [bind]
+  (if (clojure.string/includes? bind ":")
+    (let [[host port] (clojure.string/split bind #":")]
+      (PortBinding/of host ^String port))
+    (PortBinding/of "0.0.0.0" ^String bind)))
+
+(defn filter-host [s]
+  (if (clojure.string/includes? s ":")
+    (second (clojure.string/split s #":"))
+    s))
+
 (defn port-configs-from
   [port-mapping]
   (let [host-ports      (->> port-mapping
                              (keys)
                              (map str)
-                             (map #(vector % [(PortBinding/of "0.0.0.0" ^String %)]))
+                             (map #(vector % [(port-binding-default-public %)]))
+                             (reduce (fn [acc [k v]]
+                                       (assoc acc (filter-host k) v)) {})
                              (into {}))
         container-ports (->> port-mapping
                              (vals)

--- a/test/clj_docker_client/core_test.clj
+++ b/test/clj_docker_client/core_test.clj
@@ -193,6 +193,21 @@
             _ (rm conn container-id)]
           (is (not (nil? ip)))
           (is (correct-ip? ip))))
+    (testing "Port binding with different IP"
+      (let [image "redis:alpine"
+            _     (pull conn image)
+            id    (create conn image "redis-server" {} {"127.0.0.1:6379" "6379"})
+            id    (start conn id)
+            info  (first (filter #(= id (:id %)) (ps conn true)))]
+        (is (correct-id? id))
+        (is (= :running (:state info)))
+        (is (= [{:public  6379
+                 :private 6379
+                 :type    :tcp
+                 :ip      "127.0.0.1"}] (:ports info)))
+        (kill conn id)
+        (rm conn id)
+        (image-rm conn image)))
     (testing "Removing a container"
       (let [id (create conn img "echo hello" {:k "v"} {})
             _  (rm conn id)]


### PR DESCRIPTION
Enables the usage of `10.0.0.1:1337` in the host part of the port
config, to bind the container to specific interfaces.

Example:

```clojure
(run conn "redis:alpine" "redis-server" {} {"10.0.0.1:6379" "6379"})
```

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>