### PR TITLE
Add support for stats, only cpu and memory in a similar way 'docker s…

### DIFF
--- a/src/clj_docker_client/core.clj
+++ b/src/clj_docker_client/core.clj
@@ -329,6 +329,13 @@
   [^DockerClient connection ^String container]
   (u/spotify-obj->Map (.inspectContainer connection container)))
 
+(defn stats
+  "Returns the resource stats of a created container by name or id/name."
+  [^DockerClient connection name]
+  (-> connection
+      (.stats name)
+      (u/ContainerStats->Map name)))
+
 ;; Networks
 
 (defn network-create

--- a/test/clj_docker_client/core_test.clj
+++ b/test/clj_docker_client/core_test.clj
@@ -201,6 +201,17 @@
             _            (rm conn container-id)]
         (is (not (nil? ip)))
         (is (correct-ip? ip))))
+    (testing "Taking stats of a container"
+      (let [container-id (create conn img "sleep 10" {} {})
+            _ (start conn container-id)
+            stat-res-1 (stats conn container-id)
+            stat-res-2 (stats conn container-id)
+            _ (stop conn container-id)
+            _ (rm conn container-id)]
+        (is (nil? (:cpu-pct stat-res-1)))
+        (is (not (nil? (:cpu-pct stat-res-2))))
+        (is (double? (:mem-mib stat-res-1)))
+        (is (double? (:mem-pct stat-res-1)))))
     (testing "Port binding with different IP"
       (let [image "redis:alpine"
             _     (pull conn image)


### PR DESCRIPTION
…tats' returns them
see https://github.com/lispyclouds/clj-docker-client/issues/7
Closes #7 