### PR TITLE
Allow Container creation with network-mode specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ which closes it after use.
 ; Binds on 0.0.0.0 in the host by default.
 (docker/create conn "busybox:musl" "echo hello" {:env "testing"} {8000 8000} "/working/dir" "user")
 => "9a9ce5dc847c"
+
+(docker/create {:connection conn :image "busybox:musl" 
+	:command "echo hello" :env {:test_var "abc"} 
+	:exposed-ports {8000 8000}
+	:working-dir "/usr/src/app"  ":user "testuser" 
+	:network-mode "host"})
 ```
 
 #### Listing all available containers
@@ -540,18 +546,18 @@ Create a TarArchiveInputStream to process the file(s) in it.
 
 #### Connect a container to a network
 ```clojure
-(docker/network-connect "sky-net" "container id")
+(docker/network-connect conn "sky-net" "container id")
 => "13c274fc67e6"
 ```
 
 #### Disconnect a container from a network
 ```clojure
-(docker/network-disconnect "sky-net" "container id")
+(docker/network-disconnect conn "sky-net" "container id")
 => "13c274fc67e6"
 ```
 
 #### Remove a network
 ```clojure
-(docker/network-rm "sky-net")
+(docker/network-rm conn "sky-net")
 => "sky-net"
 ```

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ which closes it after use.
 (docker/create conn "busybox:musl" "echo hello" {:env "testing"} {8000 8000} "/working/dir" "user")
 => "9a9ce5dc847c"
 
+(docker/create conn {:image "busybox:musl" 
+	:command "echo hello" :env {:test_var "abc"} 
+	:exposed-ports {8000 8000}
+	:working-dir "/usr/src/app"  ":user "testuser" 
+	:network-mode "host"})
+	
 (docker/create {:connection conn :image "busybox:musl" 
 	:command "echo hello" :env {:test_var "abc"} 
 	:exposed-ports {8000 8000}

--- a/src/clj_docker_client/core.clj
+++ b/src/clj_docker_client/core.clj
@@ -170,8 +170,10 @@
          env-vars (if env env {})
          exp-ports (if exposed-ports exposed-ports {})]
      (create connection image cmd env-vars exp-ports working-dir user props)))
-  ([connection image]
-   (create connection image "" {} {} nil nil))
+  ([connection image-or-props]
+   (if (map? image-or-props)
+     (create (assoc image-or-props :connection connection))
+     (create connection image-or-props "" {} {} nil nil)))
   ([connection image cmd]
    (create connection image cmd {} {} nil nil))
   ([connection image cmd env-vars]

--- a/src/clj_docker_client/core.clj
+++ b/src/clj_docker_client/core.clj
@@ -184,7 +184,6 @@
    (create connection image cmd env-vars exposed-ports working-dir nil))
   ([^DockerClient connection image cmd env-vars exposed-ports working-dir user
     & [{:keys [network-mode] :as props}]]
-   (println "network-mode" network-mode)
    (let [creation ^CreateContainerCmd (-> (.createContainerCmd connection image)
                                           
                                           (.withCmd ^"[Ljava.lang.String;"


### PR DESCRIPTION
Currently there is no way to create "host" mode containers 
(A container cannot connect to a `host` network after it's creation)

Solves #13 
`create` accepts a map, with all the properties needed, this should also make adding more properties easier. Backward compatibility is maintained. 