### PR TITLE
Changing to connect everytime

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 ;   You should have received a copy of the GNU Lesser General Public License
 ;   along with clj-docker-client. If not, see <http://www.gnu.org/licenses/>.
 
-(defproject lispyclouds/clj-docker-client "0.5.1"
+(defproject lispyclouds/clj-docker-client "0.5.2"
   :author "Rahul De <rahul@mailbox.org>"
   :url "https://github.com/lispyclouds/clj-docker-client"
   :description "An idiomatic data-driven clojure client for Docker."

--- a/test/clj_docker_client/core_test.clj
+++ b/test/clj_docker_client/core_test.clj
@@ -16,27 +16,15 @@
 (ns clj-docker-client.core-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
-            [clj-docker-client.core :refer :all]))
+            [clj-docker-client.core :refer :all])
+  (:import (clj_docker_client.socket TunnelingUnixSocket)
+           (okhttp3 OkHttpClient)))
 
 (def latest-version "v1.40")
 
-(deftest docker-connection
-  (testing "successful connection to the socket"
-    (is (map? (connect {:uri "unix:///var/run/docker.sock"}))))
-
-  (testing "connection with usupported protocol"
-    (is (thrown? IllegalArgumentException
-                 (connect {:uri "http://this-does-not-work"}))))
-
-  (testing "connection with set timeouts"
-    (let [{:keys [client]} (connect {:uri             "unix:///var/run/docker.sock"
-                                     :connect-timeout 10
-                                     :read-timeout    2000
-                                     :write-timeout   3000})]
-      (is (and (= 10 (.connectTimeoutMillis client))
-               (= 2000 (.readTimeoutMillis client))
-               (= 3000 (.writeTimeoutMillis client))
-               (= 0 (.callTimeoutMillis client)))))))
+(deftest docker-connect-map
+  (testing "deprecated connect returns map"
+    (is (map? (connect {:uri "unix:///var/run/docker.sock"})))))
 
 (deftest fetch-categories
   (testing "listing all available categories in latest version"


### PR DESCRIPTION
Since we had problems using this lib in bob, we decided to change the
behaviour to connect everytime you call invoke. The connect function is
now deprecated and only returns a map to avoid breaking the api. You
still are able to use client like before but it is discouraged now
to use connect and only using invoke is also sufficient.

Refers https://github.com/lispyclouds/clj-docker-client/issues/20